### PR TITLE
feat: 멤버 생성 시 응답으로 지하철 정보 같이 응답

### DIFF
--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/MemberService.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/MemberService.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
+    private val subwayStationService: SubwayStationService,
 ) {
     suspend fun findMember(id: String): Member {
         return memberRepository.findMemberById(ObjectId(id))
@@ -26,11 +27,16 @@ class MemberService(
 
     suspend fun createMember(
         member: Member,
-        subwayStationIds: List<String>,
+        subwayStationNames: List<String>,
     ): Member {
+        val subwayStations = subwayStationService.findSubwayStationsByNames(subwayStationNames)
+
         return try {
             memberRepository.save(
-                member.copy(code = generateMemberCode()),
+                member.copy(
+                    code = generateMemberCode(),
+                    subwayStations = subwayStations,
+                ),
             )
                 .awaitFirstOrNull()
                 ?: throw IllegalArgumentException()

--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/SubwayStationService.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/SubwayStationService.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service
 class SubwayStationService(
     private val subwayStationRepository: SubwayStationRepository,
 ) {
-    suspend fun findSubwayStationsByName(name: String): List<SubwayStation> {
+    suspend fun findSubwayStationsNameContains(name: String): List<SubwayStation> {
         return subwayStationRepository.searchNameContains(name)
     }
 

--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/SubwayStationService.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/SubwayStationService.kt
@@ -7,7 +7,11 @@ import org.springframework.stereotype.Service
 class SubwayStationService(
     private val subwayStationRepository: SubwayStationRepository,
 ) {
-    suspend fun subwayStationsByName(name: String): List<SubwayStation> {
-        return subwayStationRepository.search(name)
+    suspend fun findSubwayStationsByName(name: String): List<SubwayStation> {
+        return subwayStationRepository.searchNameContains(name)
+    }
+
+    suspend fun findSubwayStationsByNames(subwayStationNames: List<String>): List<SubwayStation> {
+        return subwayStationRepository.searchByNames(subwayStationNames)
     }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberController.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberController.kt
@@ -53,7 +53,7 @@ class MemberController(
         val member =
             memberService.createMember(
                 member = memberRequest.toDomain(),
-                subwayStationIds = memberRequest.subwayStations,
+                subwayStationNames = memberRequest.subwayStations,
             )
 
         return ApiResponseDto(

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/SubwayStationController.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/SubwayStationController.kt
@@ -19,7 +19,7 @@ class SubwayStationController(
     suspend fun search(
         @RequestParam query: String,
     ): ApiResponseDto<List<SubwayStationDto.SubwayStationResponse>> {
-        val subwayStations = subwayStationService.subwayStationsByName(query)
+        val subwayStations = subwayStationService.findSubwayStationsByName(query)
 
         return ApiResponseDto(
             status = "200",

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/SubwayStationController.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/SubwayStationController.kt
@@ -19,7 +19,7 @@ class SubwayStationController(
     suspend fun search(
         @RequestParam query: String,
     ): ApiResponseDto<List<SubwayStationDto.SubwayStationResponse>> {
-        val subwayStations = subwayStationService.findSubwayStationsByName(query)
+        val subwayStations = subwayStationService.findSubwayStationsNameContains(query)
 
         return ApiResponseDto(
             status = "200",

--- a/api/src/test/kotlin/kr/co/funch/api/domain/member/MemberServiceTest.kt
+++ b/api/src/test/kotlin/kr/co/funch/api/domain/member/MemberServiceTest.kt
@@ -14,9 +14,11 @@ import java.time.LocalDateTime
 class MemberServiceTest : BehaviorSpec() {
     init {
         val memberRepository: MemberRepository = mockk()
+        val subwayStationService: SubwayStationService = mockk()
         val sut =
             MemberService(
                 memberRepository = memberRepository,
+                subwayStationService = subwayStationService,
             )
 
         Given("MemberService") {


### PR DESCRIPTION
- 멤버 생성 시 들어오는 지하철역 이름으로 지하철역 정보 검색
- 응답에 subwayStationInfo 담아서 전달

```json
{
  "status": "201",
  "message": "CREATED",
  "data": {
    "id": "65d1aaea2a27494b4079e171",
    "name": "string",
    "bloodType": "A",
    "jobGroup": "개발자",
    "clubs": [
      "NEXTERS"
    ],
    "subwayInfos": [
      {
        "name": "충무로",
        "lines": [
          "THREE",
          "FOUR"
        ]
      },
      {
        "name": "회기",
        "lines": [
          "GYEONGCHUN",
          "ONE",
          "GYEONGUI"
        ]
      }
    ],
    "mbti": "ISTJ",
    "memberCode": "K4A1",
    "viewCount": 0
  }
}
```

close #32 