### PR TITLE
chore: API 문서에 enum값 표시되도록 수정

### DIFF
--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/model/BloodType.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/model/BloodType.kt
@@ -1,8 +1,19 @@
 package kr.co.funch.api.domain.member.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
+
 enum class BloodType(val additionalInfo: String) {
     A("꼼꼼하고 배려심있지만 부끄러움이 많아요"),
     B("호기심과 창의력을 갖췄지만 변덕스러워요"),
     AB("브레인으로 불리지만 감정기복이 심해요"),
     O("열정과 노력이 있지만 겸손함이 부족해요"),
+    ;
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun from(value: String): BloodType {
+            return BloodType.valueOf(value.uppercase())
+        }
+    }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/model/Club.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/model/Club.kt
@@ -1,7 +1,18 @@
 package kr.co.funch.api.domain.member.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
+
 enum class Club {
     NEXTERS,
     SOPT,
     DEPROMEET,
+    ;
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun from(value: String): Club {
+            return Club.valueOf(value.uppercase())
+        }
+    }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/model/JobGroup.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/model/JobGroup.kt
@@ -1,6 +1,17 @@
 package kr.co.funch.api.domain.member.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
+
 enum class JobGroup(val koreanName: String) {
     DEVELOPER("개발자"),
     DESIGNER("디자이너"),
+    ;
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun from(value: String): JobGroup {
+            return JobGroup.valueOf(value.uppercase())
+        }
+    }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/model/Mbti.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/model/Mbti.kt
@@ -1,5 +1,7 @@
 package kr.co.funch.api.domain.member.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
+
 enum class Mbti(val additionalInfo: String) {
     ENFJ("사심없는 따뜻함을 가진 인자한 지도자 타입"),
     ENFP("감당불가 친화력을 가진 인간 리트리버 타입"),
@@ -17,4 +19,13 @@ enum class Mbti(val additionalInfo: String) {
     ISFP("따뜻한 감성을 가진 프로취존러 타입"),
     ISTJ("한번 시작한 일은 끝내는 불도저 타입"),
     ISTP("재주가 많지만 시작이 힘든 귀차니스트"),
+    ;
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun from(value: String): Mbti {
+            return Mbti.valueOf(value.uppercase())
+        }
+    }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/MemberDto.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/MemberDto.kt
@@ -13,11 +13,11 @@ object MemberDto {
     data class MemberResponse(
         val id: String,
         val name: String,
-        val bloodType: String,
+        val bloodType: BloodType,
         val jobGroup: String,
-        val clubs: List<String>,
+        val clubs: List<Club>,
         val subwayInfos: List<SubwayInfo>,
-        val mbti: String,
+        val mbti: Mbti,
         val memberCode: String,
         val viewCount: Int,
     ) {
@@ -31,14 +31,14 @@ object MemberDto {
                 return MemberResponse(
                     id = member.id.toString(),
                     name = member.name,
-                    bloodType = member.bloodType.name,
+                    bloodType = member.bloodType,
                     jobGroup = member.jobGroup.koreanName,
-                    clubs = member.clubs.map { it.name },
+                    clubs = member.clubs,
                     subwayInfos =
                         member.subwayStations.map { station ->
                             SubwayInfo(station.name, station.lines.map { SubwayStation.SubwayLine.valueOf(it).name })
                         },
-                    mbti = member.mbti.name,
+                    mbti = member.mbti,
                     memberCode = member.code.orEmpty(),
                     viewCount = member.viewCount,
                 )
@@ -48,22 +48,22 @@ object MemberDto {
 
     data class MemberCreateRequest(
         val name: String,
-        val jobGroup: String,
-        val clubs: List<String>,
-        val bloodType: String,
+        val jobGroup: JobGroup,
+        val clubs: List<Club>,
+        val bloodType: BloodType,
         val subwayStations: List<String>,
-        val mbti: String,
+        val mbti: Mbti,
         val deviceNumber: String,
     ) {
         fun toDomain(): Member {
             return Member(
                 id = ObjectId(),
                 name = name,
-                bloodType = BloodType.valueOf(bloodType.uppercase()),
-                jobGroup = JobGroup.valueOf(jobGroup.uppercase()),
-                clubs = clubs.map { Club.valueOf(it.uppercase()) },
+                bloodType = bloodType,
+                jobGroup = jobGroup,
+                clubs = clubs,
                 subwayStations = emptyList(),
-                mbti = Mbti.valueOf(mbti.uppercase()),
+                mbti = mbti,
                 deviceNumber = deviceNumber,
                 createdAt = LocalDateTime.now(),
                 updatedAt = LocalDateTime.now(),

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/MemberMatchingDto.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/MemberMatchingDto.kt
@@ -3,7 +3,9 @@ package kr.co.funch.api.interfaces.dto
 import kr.co.funch.api.domain.matching.model.ChemistryInfo
 import kr.co.funch.api.domain.matching.model.RecommendInfo
 import kr.co.funch.api.domain.matching.model.SubwayInfo
+import kr.co.funch.api.domain.member.model.BloodType
 import kr.co.funch.api.domain.member.model.Club
+import kr.co.funch.api.domain.member.model.Mbti
 import kr.co.funch.api.domain.member.model.Member
 
 object MemberMatchingDto {
@@ -23,8 +25,8 @@ object MemberMatchingDto {
             val name: String,
             val jobGroup: String,
             val clubs: List<Club>,
-            val mbti: String,
-            val bloodType: String,
+            val mbti: Mbti,
+            val bloodType: BloodType,
             val subwayNames: List<String>,
         ) {
             companion object {
@@ -33,8 +35,8 @@ object MemberMatchingDto {
                         name = member.name,
                         jobGroup = member.jobGroup.koreanName,
                         clubs = member.clubs,
-                        mbti = member.mbti.name,
-                        bloodType = member.bloodType.name,
+                        mbti = member.mbti,
+                        bloodType = member.bloodType,
                         subwayNames = member.subwayStations.map { it.name }.toList(),
                     )
                 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/SubwayStationDto.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/SubwayStationDto.kt
@@ -6,7 +6,7 @@ object SubwayStationDto {
     data class SubwayStationResponse(
         val id: String,
         val name: String,
-        val lines: List<String>,
+        val lines: List<SubwayStation.SubwayLine>,
         val location: Location,
     ) {
         data class Location(
@@ -19,7 +19,7 @@ object SubwayStationDto {
                 return SubwayStationResponse(
                     id = subwayStation.id.toString(),
                     name = subwayStation.name,
-                    lines = subwayStation.lines.map { SubwayStation.SubwayLine.valueOf(it).name },
+                    lines = subwayStation.lines.map { SubwayStation.SubwayLine.valueOf(it) },
                     location =
                         Location(
                             latitude = subwayStation.location.latitude.toString(),


### PR DESCRIPTION
- swagger에 enum값 목록이 표시될 수 있도록 dto 들의 타입을 enum으로 수정했습니다

<img width="1333" alt="image" src="https://github.com/Nexters/funch-server/assets/54302155/8ef21322-bed7-4f0a-8ffc-0ed5a99bfd6e">

close #34 