### PR TITLE
feat:매칭 가능 여부 조회 API 개발 및 응답코드 정의 

### DIFF
--- a/api/src/main/kotlin/kr/co/funch/api/domain/matching/MemberMatchingService.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/matching/MemberMatchingService.kt
@@ -49,4 +49,9 @@ class MemberMatchingService(
             matchedSubwayLine,
         )
     }
+
+    suspend fun canMatching(targetMemberCode: String): Boolean {
+        // TODO: 호출 결과가 false이면 예외 발생 -> GlobalExceptionHandler 타도록 수정
+        return memberService.existsMemberByMemberCode(targetMemberCode)
+    }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/MemberRepository.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/MemberRepository.kt
@@ -21,6 +21,8 @@ interface MemberRepositoryCustom {
     suspend fun findByCode(code: String): Member?
 
     suspend fun deleteMemberById(id: ObjectId): Long?
+
+    suspend fun existsMemberByCode(code: String): Boolean?
 }
 
 @Repository
@@ -69,5 +71,15 @@ class MemberRepositoryCustomImpl(
                     .awaitFirstOrNull()
 
             result?.deletedCount
+        }
+
+    override suspend fun existsMemberByCode(code: String): Boolean? =
+        withContext(ioDispatcher) {
+            val criteria = Criteria()
+            criteria
+                .and("code").`is`(code)
+
+            mongoOperations.exists(Query(criteria), Member::class.java)
+                .awaitFirstOrNull()
         }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/MemberService.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/MemberService.kt
@@ -69,6 +69,11 @@ class MemberService(
         }
     }
 
+    suspend fun existsMemberByMemberCode(code: String): Boolean {
+        return memberRepository.existsMemberByCode(code)
+            ?: throw IllegalArgumentException("existsMemberByMemberCode failed - code : $code")
+    }
+
     private suspend fun generateMemberCode(): String {
         val letters = ('A'..'Z').toList()
         val numbers = ('0'..'9').toList()

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
@@ -13,5 +13,4 @@ enum class ApiResponseCode(
     FAIL("4000", "실패"),
     MATCHING_PROFILE_NOT_EXIST("4001", "매칭상대 프로필 존재하지 않음"),
     INTERNAL_ERROR("5000", "서버 오류"),
-    ;
 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 enum class ApiResponseCode(
     @get:JsonValue
     val code: String,
-    val description: String,
+    val message: String,
 ) {
     SUCCESS("1000", "성공"),
     INVALID_INPUT("2000", "입력값 오류"),

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
@@ -1,0 +1,21 @@
+package kr.co.funch.api.interfaces
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class ApiResponseCode(
+    val code: String,
+    val description: String,
+) {
+    SUCCESS("1000", "성공"),
+    INVALID_INPUT("2000", "입력값 오류"),
+    UNAUTHORIZED("3000", "인증 오류"),
+    FAIL("4000", "실패"),
+    MATCHING_PROFILE_NOT_EXIST("4001", "매칭상대 프로필 존재하지 않음"),
+    INTERNAL_ERROR("5000", "서버 오류"),
+    ;
+
+    @JsonValue
+    fun getCode(): String {
+        return code
+    }
+}

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/ApiResponseCode.kt
@@ -3,6 +3,7 @@ package kr.co.funch.api.interfaces
 import com.fasterxml.jackson.annotation.JsonValue
 
 enum class ApiResponseCode(
+    @get:JsonValue
     val code: String,
     val description: String,
 ) {
@@ -13,9 +14,4 @@ enum class ApiResponseCode(
     MATCHING_PROFILE_NOT_EXIST("4001", "매칭상대 프로필 존재하지 않음"),
     INTERNAL_ERROR("5000", "서버 오류"),
     ;
-
-    @JsonValue
-    fun getCode(): String {
-        return code
-    }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
@@ -5,6 +5,8 @@ import kr.co.funch.api.domain.matching.MemberMatchingService
 import kr.co.funch.api.interfaces.dto.ApiResponseDto
 import kr.co.funch.api.interfaces.dto.MemberMatchingDto
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -37,6 +39,23 @@ class MemberMatchingController(
                     matchedInfos = memberMatching.getMatchedInfos(),
                     subwayChemistryInfo = memberMatching.getSubwayChemistryInfo(),
                 ),
+        )
+    }
+
+    @Operation(summary = "프로필 매칭 가능 여부 조회")
+    @GetMapping("/{targetMemberCode}")
+    suspend fun isPossible(
+        @PathVariable targetMemberCode: String,
+    ): ApiResponseDto<Unit> {
+        val canMatching = memberMatchingService.canMatching(targetMemberCode)
+
+        // TODO: GlobalExceptionHandler에 위임
+        if (canMatching) {
+            return ApiResponseDto()
+        }
+
+        return ApiResponseDto(
+            code = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST,
         )
     }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
@@ -56,7 +56,7 @@ class MemberMatchingController(
 
         return ApiResponseDto(
             code = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST,
-            message = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST.message
+            message = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST.message,
         )
     }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
@@ -2,6 +2,7 @@ package kr.co.funch.api.interfaces
 
 import io.swagger.v3.oas.annotations.Operation
 import kr.co.funch.api.domain.matching.MemberMatchingService
+import kr.co.funch.api.interfaces.dto.ApiResponseCodeDto
 import kr.co.funch.api.interfaces.dto.ApiResponseDto
 import kr.co.funch.api.interfaces.dto.MemberMatchingDto
 import org.springframework.http.HttpStatus
@@ -46,15 +47,15 @@ class MemberMatchingController(
     @GetMapping("/{targetMemberCode}")
     suspend fun isPossible(
         @PathVariable targetMemberCode: String,
-    ): ApiResponseDto<Unit> {
+    ): ApiResponseCodeDto<Unit> {
         val canMatching = memberMatchingService.canMatching(targetMemberCode)
 
         // TODO: GlobalExceptionHandler에 위임
         if (canMatching) {
-            return ApiResponseDto()
+            return ApiResponseCodeDto()
         }
 
-        return ApiResponseDto(
+        return ApiResponseCodeDto(
             code = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST,
             message = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST.message,
         )

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/MemberMatchingController.kt
@@ -56,6 +56,7 @@ class MemberMatchingController(
 
         return ApiResponseDto(
             code = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST,
+            message = ApiResponseCode.MATCHING_PROFILE_NOT_EXIST.message
         )
     }
 }

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/ApiResponseCodeDto.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/ApiResponseCodeDto.kt
@@ -1,9 +1,12 @@
 package kr.co.funch.api.interfaces.dto
 
+import kr.co.funch.api.interfaces.ApiResponseCode
 import org.springframework.http.HttpStatus
 
-data class ApiResponseDto<T>(
+// TODO: 클라이언트쪽 코드에 code 반영 이후 ApiResponseDto로 통합
+data class ApiResponseCodeDto<T>(
     val status: String = HttpStatus.OK.value().toString(),
     val message: String? = HttpStatus.OK.reasonPhrase,
+    val code: ApiResponseCode = ApiResponseCode.SUCCESS,
     val data: T? = null,
 )

--- a/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/ApiResponseDto.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/interfaces/dto/ApiResponseDto.kt
@@ -1,7 +1,11 @@
 package kr.co.funch.api.interfaces.dto
 
+import kr.co.funch.api.interfaces.ApiResponseCode
+import org.springframework.http.HttpStatus
+
 data class ApiResponseDto<T>(
-    val status: String,
-    val message: String?,
-    val data: T?,
+    val status: String = HttpStatus.OK.value().toString(),
+    val message: String? = HttpStatus.OK.reasonPhrase,
+    val code: ApiResponseCode = ApiResponseCode.SUCCESS,
+    val data: T? = null,
 )


### PR DESCRIPTION
- 프로필이 존재하는지 DB에 조회해서 매칭 가능 여부 조회 
  - 프로필 매칭 시 로딩 화면 띄우기 전에 체크하는 용도
- 클라이언트 측에서 예외 처리를 위한 API 응답코드 정의
  - 1000(성공), 2000(입력 오류), 3000(인증 오류), 4000(로직상 오류), 5000(서버 오류) 대역을 대략 나눠봤는데 더 좋은 아이디어가 있다면 의견 부탁드림당 ㅎㅎ
- 매칭 가능 여부부터 적용 (기존 API는 추후 적용)
  - 매칭 불가 시에는 응답코드 4001로 개발
  - 추후 ExceptionHandler 통해서 예외 발생 시 응답에 코드 세팅하도록 개발 예정

close #43 