### PR TITLE
feat: 지하철 이름이 '역'으로 끝나면 '역'을 제거하고 쿼리 조회

### DIFF
--- a/api/src/main/kotlin/kr/co/funch/api/domain/member/SubwayStationService.kt
+++ b/api/src/main/kotlin/kr/co/funch/api/domain/member/SubwayStationService.kt
@@ -7,11 +7,25 @@ import org.springframework.stereotype.Service
 class SubwayStationService(
     private val subwayStationRepository: SubwayStationRepository,
 ) {
-    suspend fun findSubwayStationsNameContains(name: String): List<SubwayStation> {
+    suspend fun findSubwayStationsNameContains(query: String): List<SubwayStation> {
+        val name =
+            if (query !in STATION_NAME_POSTFIX_TRIM_EXCEPTION_LIST && query.endsWith(STATION_NAME_POSTFIX)) {
+                query.substring(0, query.length - 1)
+            } else {
+                query
+            }
         return subwayStationRepository.searchNameContains(name)
     }
 
     suspend fun findSubwayStationsByNames(subwayStationNames: List<String>): List<SubwayStation> {
         return subwayStationRepository.searchByNames(subwayStationNames)
+    }
+
+    companion object {
+        const val STATION_NAME_POSTFIX = "역"
+        val STATION_NAME_POSTFIX_TRIM_EXCEPTION_LIST =
+            setOf(
+                "서울역",
+            )
     }
 }


### PR DESCRIPTION
- '서울역' 같이 예외 처리가 필요한 케이스는 별도 리스트로 관리